### PR TITLE
refactor(rst): rename the rst language to restructuredtext

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,8 +44,10 @@
 				]
 			},
 			{
-				"id": "rst",
+				"id": "restructuredtext",
 				"aliases": [
+          "reStructuredText",
+          "rst",
 					"RST",
 					"ReStructured Text"
 				],

--- a/package.json
+++ b/package.json
@@ -44,20 +44,6 @@
 				]
 			},
 			{
-				"id": "restructuredtext",
-				"aliases": [
-          "reStructuredText",
-          "rst",
-					"RST",
-					"ReStructured Text"
-				],
-				"extensions": [
-					".rst",
-					".rest",
-					".hrst"
-				]
-			},
-			{
 				"id": "jade",
 				"aliases": [
 					"Pug",

--- a/src/previewDocumentContentProvider.ts
+++ b/src/previewDocumentContentProvider.ts
@@ -66,7 +66,7 @@ export class PreviewDocumentContentProvider implements TextDocumentContentProvid
             case "mermaid":
                 thiz._documentContentManager = new mermaidDocumentContentManager.MermaidDocumentContentManager(editor);
                 break;
-            case "rst":
+            case "restructuredtext":
                 thiz._documentContentManager = new reStructuredTextDocumentContentManager.ReStructuredTextDocumentContentManager(editor);
                 break;
             case "image":

--- a/src/util/vscodeHelper.ts
+++ b/src/util/vscodeHelper.ts
@@ -30,7 +30,7 @@ export class VscodeHelper {
                 label: "markdown",
                 description: "Preview Markdown"
             }, {
-                label: "rst",
+                label: "restructuredtext",
                 description: "Preview ReStructuredText"
             }, {
                 label: "html",
@@ -64,7 +64,7 @@ export class VscodeHelper {
             case "markdown":
             case "css":
             case "mermaid":
-            case "rst":
+            case "restructuredtext":
                 return Promise.resolve(editor.document.languageId);
             default:
                 break;


### PR DESCRIPTION
~~This aligns the language ID with
https://marketplace.visualstudio.com/items?itemName=lextudio.restructuredtext. The `restructuredtext` language ID was chosen over `rst`, because it’s more explicit, and it’s already supported by
https://marketplace.visualstudio.com/items?itemName=vscode-icons-team.vscode-icons.~~

~~`rst` was added as an alias. Also `reStructuredText` was added as the first alias, because that’s used as the display name.~~

Actually `restructuredtext` is builtin to VSCode (https://github.com/microsoft/vscode/blob/e244acbb172c428cb219717a07bf55d2737492ca/extensions/restructuredtext/package.json#L16-L27). So the language definition might as well be removed entirely.